### PR TITLE
Don't die if announce URL not found.

### DIFF
--- a/BitTornado/reannounce.py
+++ b/BitTornado/reannounce.py
@@ -6,7 +6,10 @@ def reannounce(fname, announce, announce_list=None, verbose=False):
     metainfo = MetaInfo.read(fname)
 
     if verbose:
-        print 'old announce for %s: %s' % (fname, metainfo['announce'])
+        try:
+            print 'old announce for %s: %s' % (fname, metainfo['announce'])
+        except KeyError:
+            print 'No announce found.'
 
     metainfo['announce'] = announce
 


### PR DESCRIPTION
rtorrent state "torrent" files don't have an announce URLs but don't care if they are added.
Now we can reannounce torrents that are already running.

Stop rtorrent, reannounce both state files (and the tied torrent if exist)
Delete the <HASH>.torrent.libtorrent_resume
??????
Profit!!!
