### PR TITLE
Fix for stacktrace:

### DIFF
--- a/BitTornado/Tracker/track.py
+++ b/BitTornado/Tracker/track.py
@@ -706,7 +706,7 @@ class Tracker:
         if params('supportcrypto', 0):
             supportcrypto = 1
             try:
-                s = int(params['requirecrypto'], 0)
+                s = int(params('requirecrypto', 0))
                 chr(s)
             except (KeyError, ValueError):
                 s = 0

--- a/BitTornado/Tracker/track.py
+++ b/BitTornado/Tracker/track.py
@@ -703,10 +703,10 @@ class Tracker:
             raise ValueError('invalid amount left')
         #uploaded = long(params('uploaded',''))
         #downloaded = long(params('downloaded',''))
-        if params('supportcrypto'):
+        if params('supportcrypto', 0):
             supportcrypto = 1
             try:
-                s = int(params['requirecrypto'])
+                s = int(params['requirecrypto'], 0)
                 chr(s)
             except (KeyError, ValueError):
                 s = 0


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/local/sbin/bittornado/BitTornado/Network/RawServer.py", line 132, in listen_forever
    self.sockethandler.handle_events(events)
  File "/usr/local/sbin/bittornado/BitTornado/Network/SocketHandler.py", line 302, in handle_events
    s.handler.data_came_in(s, data)
  File "/usr/local/sbin/bittornado/BitTornado/Tracker/HTTPHandler.py", line 145, in data_came_in
    if not c.data_came_in(data) and not c.closed:
  File "/usr/local/sbin/bittornado/BitTornado/Tracker/HTTPHandler.py", line 35, in data_came_in
    self.next_func = self.next_func(val)
  File "/usr/local/sbin/bittornado/BitTornado/Tracker/HTTPHandler.py", line 67, in read_header
    r = self.handler.getfunc(self, self.path, self.headers)
  File "/usr/local/sbin/bittornado/BitTornado/Tracker/track.py", line 1008, in get
    rsize = self.add_data(infohash, event, ip, paramslist)
  File "/usr/local/sbin/bittornado/BitTornado/Tracker/track.py", line 709, in add_data
    s = int(params['requirecrypto'])
TypeError: 'function' object has no attribute '__getitem__'