### PR TITLE
Add missing Python submodules to the distributed packages.

### DIFF
--- a/BitTornado/Application/makemetafile.py
+++ b/BitTornado/Application/makemetafile.py
@@ -69,7 +69,10 @@ def make_meta_file(loc, url, params=None, flag=None,
     if flag is not None and flag.is_set():
         return
 
-    metainfo = MetaInfo(announce=url, info=info, **params)
+    newparams = { key:val for key, val in params.items() \
+                          if key in MetaInfo.typemap }
+
+    metainfo = MetaInfo(announce=url, info=info, **newparams)
     metainfo.write(params['target'])
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,13 @@ setup(
     description="John Hoffman's fork of the original bittorrent",
     license="MIT",
 
-    packages=["BitTornado"],
+    packages=["BitTornado",
+              "BitTornado.Application",
+              "BitTornado.Client",
+              "BitTornado.Meta",
+              "BitTornado.Network",
+              "BitTornado.Storage",
+              "BitTornado.Tracker"],
 
     scripts=["btdownloadheadless.py", "bttrack.py", "btmakemetafile.py",
              "btlaunchmany.py", "btcompletedir.py", "btdownloadcurses.py",


### PR DESCRIPTION
Packages created with `pip` will be largely incomplete because `setup.py` only references the `BitTorrent` module. This patch manually adds all relevant submodules. There is a more automatic way, using `setuptools`’s `find_packages`, but it gives you less control.