### PR TITLE
Sanitize MetaInfo constructor arguments.

### DIFF
--- a/BitTornado/Application/makemetafile.py
+++ b/BitTornado/Application/makemetafile.py
@@ -69,7 +69,10 @@ def make_meta_file(loc, url, params=None, flag=None,
     if flag is not None and flag.is_set():
         return
 
-    metainfo = MetaInfo(announce=url, info=info, **params)
+    newparams = { key:val for key, val in params.items() \
+                          if key in MetaInfo.typemap }
+
+    metainfo = MetaInfo(announce=url, info=info, **newparams)
     metainfo.write(params['target'])
 
 


### PR DESCRIPTION
Since the MetaInfo class is now more robust than before, `make_meta_file()`
needs to sanitize the arguments it sends to its constructor. This patch
filters out all dictionary keys unknown to MetaInfo.

Without this patch, `make_meta_file()` always crashes.