### PR TITLE
Support for the 'private' torrent flag in MetaInfo.

### DIFF
--- a/BitTornado/Meta/Info.py
+++ b/BitTornado/Meta/Info.py
@@ -190,7 +190,7 @@ class Info(TypedDict):   # pylint: disable=R0904
             typemap = {'length': int, 'path': Path}
         valtype = File
     typemap = {'name': str, 'piece length': int, 'pieces': bytes,
-               'files': Files, 'length': int}
+               'files': Files, 'length': int, 'private': int}
 
     def __init__(self, name, size=None,
                  progress=lambda x: None, progress_percent=False, **params):
@@ -229,6 +229,8 @@ class Info(TypedDict):   # pylint: disable=R0904
         else:
             self['files'] = []
             self['length'] = size
+
+        self['private'] = params['private'] if 'private' in params else False
 
         if 'pieces' in params:
             pieces = params['pieces']


### PR DESCRIPTION
This simple patch allows to create private torrents as per [BEP-0027](http://www.bittorrent.org/beps/bep_0027.html).

As a side note, the additional safeties added to the `Info` class seem to have brought their share of issues, including this one. It doesn’t seem very pythonish to me to hardcode what `info` can contain, as it will cause problems with extensions (and future extensions). For instance the `root hash` field ([BEP-0030](http://www.bittorrent.org/beps/bep_0030.html)) should be allowed, too.

Also I could not find an elegant way to say that `private` is actually an optional field, so it is always serialised in the torrent. Does it suit you nonetheless?