### PR TITLE
Metafile cleanup

### DIFF
--- a/BitTornado/Application/makemetafile.py
+++ b/BitTornado/Application/makemetafile.py
@@ -6,7 +6,7 @@ from BitTornado.Meta.BTTree import BTTree
 from BitTornado.Meta.Info import MetaInfo
 
 defaults = [
-    ('announce_list', '',
+    ('announce-list', '',
         'a list of announce URLs - explained below'),
     ('httpseeds', '',
         'a list of http seed URLs - explained below'),
@@ -24,7 +24,7 @@ defaults = [
 ignore = ['core', 'CVS']
 
 announcelist_details = \
-    """announce_list = optional list of redundant/backup tracker URLs, in the
+    """announce-list = optional list of redundant/backup tracker URLs, in the
 format:
     url[,url...][|url[,url...]...]
         where URLs separated by commas are all tried first

--- a/BitTornado/Meta/Info.py
+++ b/BitTornado/Meta/Info.py
@@ -399,6 +399,7 @@ class MetaInfo(TypedDict, BencodedFile):
     typemap = {'info': Info, 'announce': str, 'creation date': int,
                'comment': str, 'announce-list': AnnounceList,
                'httpseeds': HTTPList}
+    ignore_invalid = True
 
     def __init__(self, *args, **kwargs):
         super(MetaInfo, self).__init__(*args, **kwargs)

--- a/BitTornado/Meta/Info.py
+++ b/BitTornado/Meta/Info.py
@@ -398,7 +398,7 @@ class MetaInfo(TypedDict, BencodedFile):
 
     typemap = {'info': Info, 'announce': str, 'creation date': int,
                'comment': str, 'announce-list': AnnounceList,
-               'httpseeds': HTTPList}
+               'httpseeds': HTTPList, 'created by': str, 'encoding': str}
     ignore_invalid = True
 
     def __init__(self, *args, **kwargs):

--- a/BitTornado/Meta/TypedCollections.py
+++ b/BitTornado/Meta/TypedCollections.py
@@ -63,6 +63,7 @@ class SplitList(TypedList):
 class TypedDict(dict):
     keytype = valtype = keymap = valmap = valid_keys = typemap = None
     keyconst = valconst = None
+    ignore_invalid = False
 
     def __init__(self, mapping=None, **kwargs):
         if self.typemap is not None and self.valid_keys is None:
@@ -104,6 +105,8 @@ class TypedDict(dict):
             val = self.typemap[key](val)
 
         if self.valid_keys is not None and key not in self.valid_keys:
+            if self.ignore_invalid:
+                return
             raise KeyError('Invalid key: ' + key)
 
         if self.keyconst is not None:


### PR DESCRIPTION
Permits `TypedDict` to silently ignore invalid keys, and enables this behavior in `MetaInfo`. Two fields used by the Transmission client are now accepted.

API change: `announce_list` CLI argument is now `announce-list`, matching the `MetaInfo` field.

May resolve #17.