### PR TITLE
BF: Use integer mtime for parsed directory

### DIFF
--- a/BitTornado/Application/parsedir.py
+++ b/BitTornado/Application/parsedir.py
@@ -47,8 +47,8 @@ def parsedir(directory, parsed, files, blocked, exts=('.torrent',),
 
     # removed_files = (files \ new_files) U changed_files
     removed_files = {path: files[path] for path in files
-                     if path not in new_files
-                     or files[path][0] != new_files[path][0]}
+                     if path not in new_files or
+                     files[path][0] != new_files[path][0]}
 
     # Missing files are removed
     removed = {filehash: parsed[filehash]
@@ -132,7 +132,8 @@ def get_files(directory, exts=('.torrent',)):
 
         extmatches = [ext[1:] for ext in exts if sub.endswith(ext)]
         if extmatches:
-            files[loc] = [(os.path.getmtime(loc), os.path.getsize(loc)), 0]
+            files[loc] = [(int(os.path.getmtime(loc)), os.path.getsize(loc)),
+                          0]
             file_type[loc] = extmatches[0]
 
     # Recurse if no valid files found


### PR DESCRIPTION
`parsedir` is only called from `Client.launchmanycore.LaunchMany.scan()` and `Tracker.track.Tracker.parse_allowed()`. In the former case, the affected `dict`, `file_cache` is only used in repeated calls to `parsedir`. In the latter, the affected `dict`, `allowed_dir_files` also exists in the `Tracker.state` `dict`, which is what caused #25 in the first place.

The only potentially negative impact of this change I can see is if a file of the same length is placed in the same directory before the clock rolls over to a new second. The alternative fix would be to coerce the `float` to an `int` at save time, which would result in having to re-parse the directory anyway, as the `mtime`s would no longer match.

Closes #25.