### PR TITLE
BF: Tracker update bugs

### DIFF
--- a/BitTornado/Network/NatCheck.py
+++ b/BitTornado/Network/NatCheck.py
@@ -192,11 +192,6 @@ class NatCheck(object):
                     self.answer(False)
                 return
             self.next_len, self.next_func = x
-            if self.next_len < 0:  # already checked buffer
-                return             # wait for additional data
-            if self.bufferlen is not None:
-                self._read2(b'')
-                return
 
     def connection_lost(self, connection):
         if not self.closed:

--- a/BitTornado/Tracker/track.py
+++ b/BitTornado/Tracker/track.py
@@ -129,7 +129,7 @@ class TrackerState(TypedDict, BencodedFile):
             class PeerInfo(TypedDict):
                 typemap = {'ip': str, 'port': int, 'left': int, 'nat': bool,
                            'requirecrypto': bool, 'supportcrypto': bool,
-                           'key': str}
+                           'key': str, 'given ip': str}
             keyconst = lambda self, key: len(key) == 20
             valtype = PeerInfo
         keyconst = lambda self, key: len(key) == 20


### PR DESCRIPTION
`Network.NatCheck.NatCheck` appears to have some functionality copied from `Network.Encrypter.Connection`, but left in a check for a removed attribute.

Previous lines become a pointless branch, so removed them.

Closes #27.