### PR TITLE
BF/PY3: Error handling

### DIFF
--- a/BitTornado/Client/Rerequester.py
+++ b/BitTornado/Client/Rerequester.py
@@ -1,5 +1,4 @@
 import threading
-import socket
 import random
 from BitTornado.Meta.Info import check_type
 from io import StringIO
@@ -220,7 +219,7 @@ class Rerequester:
                 response = announcer.announce(self.infohash, self.myid,
                                               **kwargs)
                 check_peers(response)
-            except (IOError, socket.error) as e:
+            except (IOError, OSError) as e:
                 if self.lock.trip(code):
                     self.errorcodes['troublecode'] = 'Problem connecting to ' \
                         'tracker - ' + str(e)

--- a/BitTornado/Client/launchmanycore.py
+++ b/BitTornado/Client/launchmanycore.py
@@ -1,5 +1,4 @@
 import os
-import socket
 import threading
 import random
 from io import StringIO
@@ -148,7 +147,7 @@ class LaunchMany:
                         ipv6_socket_style=config['ipv6_binds_v4'],
                         upnp=upnp_type, randomizer=config['random_port'])
                     break
-                except socket.error as e:
+                except OSError as e:
                     if upnp_type and e == UPnP_ERROR:
                         self.Output.message(
                             'WARNING: COULD NOT FORWARD VIA UPnP')

--- a/BitTornado/Network/Encrypter.py
+++ b/BitTornado/Network/Encrypter.py
@@ -1,4 +1,3 @@
-import socket
 import urllib
 from binascii import hexlify
 from .BTcrypto import Crypto, padding
@@ -560,7 +559,7 @@ class Encoder(object):
             con = Connection(self, c, peerid, encrypted=encrypted)
             self.connections[c] = con
             c.set_handler(con)
-        except socket.error:
+        except OSError:
             return False
         return True
 

--- a/BitTornado/Network/NatCheck.py
+++ b/BitTornado/Network/NatCheck.py
@@ -1,4 +1,3 @@
-import socket
 from .BTcrypto import Crypto, CRYPTO_OK, padding
 from .Encrypter import protocol_name, option_pattern
 
@@ -29,9 +28,7 @@ class NatCheck(object):
             else:
                 self.encrypter = None
                 self.write(protocol_name + bytes(8) + downloadid)
-        except socket.error:
-            self.answer(False)
-        except IOError:
+        except (IOError, OSError):
             self.answer(False)
         self.next_len = len(protocol_name)
         self.next_func = self.read_header

--- a/BitTornado/Network/RawServer.py
+++ b/BitTornado/Network/RawServer.py
@@ -13,7 +13,7 @@ def autodetect_ipv6():
     try:
         assert socket.has_ipv6
         socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-    except (AssertionError, socket.error):
+    except (AssertionError, OSError):
         return 0
     return 1
 

--- a/BitTornado/Network/SocketHandler.py
+++ b/BitTornado/Network/SocketHandler.py
@@ -61,7 +61,10 @@ class SingleSocket(object):
         sock.close()
 
     def shutdown(self, val):
-        self.socket.shutdown(val)
+        try:
+            self.socket.shutdown(val)
+        except OSError:
+            pass
 
     def is_flushed(self):
         return not self.buffer

--- a/BitTornado/Network/natpunch.py
+++ b/BitTornado/Network/natpunch.py
@@ -186,7 +186,7 @@ class _UPnP(object):    # master holding class
                         break
                 else:
                     raise ValueError('couldn\'t find intranet IP')
-            except (ValueError, socket.error):
+            except (ValueError, OSError):
                 self.local_ip = None
                 if DEBUG:
                     print('Error finding local IP')

--- a/BitTornado/Tracker/track.py
+++ b/BitTornado/Tracker/track.py
@@ -796,7 +796,8 @@ class Tracker(object):
                         l = self.becache[infohash]
                         y = not peer['left']
                         for x in l:
-                            del x[y][myid]
+                            if myid in x[y]:
+                                del x[y][myid]
                     if natted >= 0:
                         del peer['nat']     # restart NAT testing
                 if natted and natted < self.natcheck:


### PR DESCRIPTION
- Check that a peerid appears in the cache before deleting.
- Permit socket.shutdown to fail silently, as failure to close a stream means it's not connected.
- `socket.error` is `OSError` in Python 3, so remove `socket.error` and check `errno`.

Closes #30.