### PR TITLE
BF: Ignore bad announce lists and HTTP seed lists

### DIFF
--- a/BitTornado/Application/reannounce.py
+++ b/BitTornado/Application/reannounce.py
@@ -15,14 +15,13 @@ def reannounce(fname, announce, announce_list=None, verbose=False):
 
     metainfo['announce'] = announce
 
-    if 'announce-list' in metainfo:
-        if verbose:
-            print('old announce-list for {}: {}'.format(
-                fname, '|'.join(','.join(tier)
-                                for tier in metainfo['announce-list'])))
-        if announce_list is not None:
-            metainfo['announce-list'] = announce_list
-        else:
-            metainfo.pop('announce-list', None)
+    if 'announce-list' in metainfo and verbose:
+        print('old announce-list for {}: {}'.format(
+              fname, '|'.join(','.join(tier)
+                              for tier in metainfo['announce-list'])))
+    if announce_list is not None:
+        metainfo['announce-list'] = announce_list
+    else:
+        metainfo.pop('announce-list', None)
 
     metainfo.write(fname)

--- a/BitTornado/Meta/Info.py
+++ b/BitTornado/Meta/Info.py
@@ -411,8 +411,10 @@ class MetaInfo(TypedDict, BencodedFile):
         if 'creation date' not in self:
             self['creation date'] = int(time.time())
 
-        # Ignore null announce-lists and httpseeds lists
+        # Ignore optional fields when null
         if self.get('announce-list') == MetaInfo.AnnounceList(''):
             del self['announce-list']
         if self.get('httpseeds') == MetaInfo.HTTPList(''):
             del self['httpseeds']
+        if self.get('comment') == '':
+            del self['comment']

--- a/BitTornado/Meta/Info.py
+++ b/BitTornado/Meta/Info.py
@@ -409,5 +409,12 @@ class MetaInfo(TypedDict, BencodedFile):
     def __init__(self, *args, **kwargs):
         super(MetaInfo, self).__init__(*args, **kwargs)
 
+        # Courtesy updates, in case we re-save MetaInfo files
         if 'creation date' not in self:
             self['creation date'] = int(time.time())
+
+        # Ignore null announce-lists and httpseeds lists
+        if self.get('announce-list') == MetaInfo.AnnounceList(''):
+            del self['announce-list']
+        if self.get('httpseeds') == MetaInfo.HTTPList(''):
+            del self['httpseeds']

--- a/BitTornado/Meta/Info.py
+++ b/BitTornado/Meta/Info.py
@@ -393,13 +393,11 @@ class MetaInfo(TypedDict, BencodedFile):
     class AnnounceList(SplitList):
         class AnnounceTier(SplitList):
             splitchar = ','
-            valtype = str
         splitchar = '|'
         valtype = AnnounceTier
 
     class HTTPList(SplitList):
         splitchar = '|'
-        valtype = str
 
     typemap = {'info': Info, 'announce': str, 'creation date': int,
                'comment': str, 'announce-list': AnnounceList,

--- a/BitTornado/Meta/TypedCollections.py
+++ b/BitTornado/Meta/TypedCollections.py
@@ -57,7 +57,11 @@ class TypedList(list):
 
 
 class SplitList(TypedList):
-    splitchar = None
+    splitchar = ' '
+
+    valtype = str    # Typically
+    valconst = bool  # Reject null values
+    error = False    # Don't fail on null values
 
     def extend(self, vals):
         if isinstance(vals, type(self.splitchar)):

--- a/BitTornado/Meta/TypedCollections.py
+++ b/BitTornado/Meta/TypedCollections.py
@@ -2,11 +2,16 @@ import urllib
 
 
 class TypedList(list):
-    valtype = valmap = valconst = None
+    valtype = valmap = None
+    error = True
 
     def __init__(self, iterable):
         super(TypedList, self).__init__()
         self.extend(iterable)
+
+    @staticmethod
+    def valconst(val):
+        return True
 
     def append(self, val):
         if self.valtype is not None and type(val) is not self.valtype:
@@ -22,10 +27,10 @@ class TypedList(list):
                     raise TypeError('Values must be of type {!r}'.format(
                                     self.valtype))
 
-        if self.valconst is not None:
-            assert self.valconst(val)
-
-        super(TypedList, self).append(val)
+        if self.valconst(val):
+            super(TypedList, self).append(val)
+        elif self.error:
+            raise ValueError('Value rejected: {}'.format(val))
 
     def __setitem__(self, key, val):
         if self.valtype is not None and type(val) is not self.valtype:
@@ -41,10 +46,10 @@ class TypedList(list):
                     raise TypeError('Values must be of type {!r}'.format(
                                     self.valtype))
 
-        if self.valconst is not None:
-            assert self.valconst(val)
-
-        super(TypedList, self).__setitem__(key, val)
+        if self.valconst(val):
+            super(TypedList, self).__setitem__(key, val)
+        elif self.error:
+            raise ValueError('Value rejected: {}'.format(val))
 
     def extend(self, vals):
         for val in vals:

--- a/btreannounce.py
+++ b/btreannounce.py
@@ -25,8 +25,8 @@ def main(argv):
                         for l in announcelist_details.split('\n')[:-2])))
 
     try:
-        opts, args = getopt.getopt(argv[1:], "hav",
-                                   ("help", "announce_list", "verbose"))
+        opts, args = getopt.getopt(argv[1:], "ha:v",
+                                   ("help", "announce_list=", "verbose"))
     except getopt.error as msg:
         print(msg)
         return 1
@@ -44,7 +44,7 @@ def main(argv):
             print(helpmsg)
             return 0
         elif opt in ('-a', '--announce_list'):
-            announce_list = [tier.split(',') for tier in arg.split('|')]
+            announce_list = arg
         elif opt in ('-v', '--verbose'):
             verbose = True
 


### PR DESCRIPTION
Turned out btreannounce wasn't working correctly, so fix that in the process.

Perhaps we should warn when changing MetaInfo?

Another alternative is to update `TypedList` to simply ignore empty strings, which has the dubious advantage of not fixing broken metafiles on resave.

Closes #36.