### PR TITLE
Correct FAQs about what port Bittornado binds to.

### DIFF
--- a/docs/FAQ.txt
+++ b/docs/FAQ.txt
@@ -23,8 +23,8 @@ A:  BitTorrent does cryptographic hashing (SHA1) of all data.  When you see "Dow
 Q:  I'm behind a firewall/NAT, can I use BT?
 
 A:  Yes, but you will get better performance if other peers can connect to you.  By
-    default, BitTorrent listens on port 6881, trying incrementially higher ports if
-    it is unable to bind, giving up after 6889 (the port range is configurable.)
+    default, BitTorrent listens on port 10000, trying incrementially higher ports if
+    it is unable to bind, giving up after 60000 (the port range is configurable.)
     It's up to you to figure out how to poke a hole in your firewall/NAT.
 
 

--- a/test/tracker/FAQ.txt
+++ b/test/tracker/FAQ.txt
@@ -23,8 +23,8 @@ A:  BitTorrent does cryptographic hashing (SHA1) of all data.  When you see "Dow
 Q:  I'm behind a firewall/NAT, can I use BT?
 
 A:  Yes, but you will get better performance if other peers can connect to you.  By
-    default, BitTorrent listens on port 6881, trying incrementially higher ports if
-    it is unable to bind, giving up after 6889 (the port range is configurable.)
+    default, BitTorrent listens on port 10000, trying incrementially higher ports if
+    it is unable to bind, giving up after 60000 (the port range is configurable.)
     It's up to you to figure out how to poke a hole in your firewall/NAT.
 
 


### PR DESCRIPTION
This is one of the Debian changes that is trivial to change.  There's a few more you may want to look into, specifically:

- 11_sorthashcheck.dpatch
- 16_fix_ipv6_in_SocketHandler.dpatch
- 17_fix_NatCheck_bufferlen_error.dpatch
- 18_fix_launchmany_encrypter.dpatch
- 25_errors_in_error_handling.dpatch
- 31_fix_for_compact_reqd_off.dpatch

As found: https://sources.debian.org/src/bittornado/0.3.18-10.3/debian/patches/